### PR TITLE
Fix decoding globally deployed services which don't have a Slot

### DIFF
--- a/Components.elm
+++ b/Components.elm
@@ -25,11 +25,13 @@ task service { status, desiredState, containerSpec, slot } =
             , ( "running-old", status.state == "running" && service.containerSpec.image /= containerSpec.image )
             ]
 
-        prepend =
-            (++)
+        slotLabel slot =
+            case slot of
+                Just s ->
+                    "." ++ toString slot
 
-        slotLabel =
-            Maybe.map (toString >> prepend ".") >> Maybe.withDefault ""
+                Nothing ->
+                    ""
     in
         li [ classList classes ]
             [ text (service.name ++ slotLabel slot)

--- a/Components.elm
+++ b/Components.elm
@@ -24,9 +24,15 @@ task service { status, desiredState, containerSpec, slot } =
             , ( "desired-" ++ desiredState, True )
             , ( "running-old", status.state == "running" && service.containerSpec.image /= containerSpec.image )
             ]
+
+        prepend =
+            (++)
+
+        slotLabel =
+            Maybe.map (toString >> prepend ".") >> Maybe.withDefault ""
     in
         li [ classList classes ]
-            [ text (service.name ++ "." ++ toString slot)
+            [ text (service.name ++ slotLabel slot)
             , br [] []
             , text (statusString status.state desiredState)
             ]

--- a/Docker.elm
+++ b/Docker.elm
@@ -21,7 +21,7 @@ withoutFailedTaskHistory : List AssignedTask -> List AssignedTask
 withoutFailedTaskHistory =
     let
         key { serviceId, slot } =
-            ( serviceId, slot )
+            ( serviceId, (Maybe.withDefault 0 slot) )
 
         latestRunning =
             List.sortBy (.status >> .timestamp >> Date.toTime)

--- a/Docker/Json.elm
+++ b/Docker/Json.elm
@@ -74,7 +74,7 @@ task =
         (Json.at [ "ID" ] Json.string)
         (Json.at [ "ServiceID" ] Json.string)
         (Json.maybe (Json.at [ "NodeID" ] Json.string))
-        (Json.at [ "Slot" ] Json.int)
+        (Json.maybe (Json.at [ "Slot" ] Json.int))
         (Json.at [ "Status" ] taskStatus)
         (Json.at [ "DesiredState" ] Json.string)
         (Json.at [ "Spec", "ContainerSpec" ] containerSpec)

--- a/Docker/Types.elm
+++ b/Docker/Types.elm
@@ -74,7 +74,7 @@ type alias Task =
     { id : String
     , serviceId : String
     , nodeId : Maybe String
-    , slot : Int
+    , slot : Maybe Int
     , status : TaskStatus
     , desiredState : String
     , containerSpec : ContainerSpec
@@ -84,7 +84,7 @@ type alias Task =
 type alias PlannedTask =
     { id : String
     , serviceId : String
-    , slot : Int
+    , slot : Maybe Int
     , status : TaskStatus
     , desiredState : String
     , containerSpec : ContainerSpec
@@ -100,7 +100,7 @@ type alias AssignedTask =
     { id : String
     , serviceId : String
     , nodeId : String
-    , slot : Int
+    , slot : Maybe Int
     , status : TaskStatus
     , desiredState : String
     , containerSpec : ContainerSpec


### PR DESCRIPTION
Should fix #2. 

Services deployed in `mode: global` don't get a Slot, since the number of replicas is equal to the number of nodes matching the placement constraint.