### PR TITLE
Support containers with no network connections

### DIFF
--- a/Docker/Json.elm
+++ b/Docker/Json.elm
@@ -43,13 +43,18 @@ network =
         (Json.at [ "Ingress" ] Json.bool)
 
 
+filterEmptyNetworks : Maybe (List NetworkId) -> Json.Decoder (List NetworkId)
+filterEmptyNetworks networks =
+    Json.succeed (Maybe.withDefault [] networks)
+
+
 service : Json.Decoder RawService
 service =
     Json.map4 RawService
         (Json.at [ "ID" ] Json.string)
         (Json.at [ "Spec", "Name" ] Json.string)
         (Json.at [ "Spec", "TaskTemplate", "ContainerSpec" ] containerSpec)
-        (Json.at [ "Endpoint", "VirtualIPs" ] (Json.list (Json.at [ "NetworkID" ] Json.string)))
+        ((Json.maybe (Json.at [ "Endpoint", "VirtualIPs" ] (Json.list (Json.at [ "NetworkID" ] Json.string)))) |> Json.andThen filterEmptyNetworks)
 
 
 date : Json.Decoder Date


### PR DESCRIPTION
This patch fixes the problem described in #11. It simply adds a Maybe when parsing the endpoints, and then filters out containers with no (swarm) network connections. They will simply appear in the grid not connected to any network.